### PR TITLE
Multiple frontends

### DIFF
--- a/hapreload.go
+++ b/hapreload.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"html/template"
 	"io/ioutil"
@@ -8,10 +9,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
-
-	"strconv"
 
 	sh "github.com/codeskyblue/go-sh"
 	"github.com/gorilla/mux"
@@ -314,6 +314,10 @@ func (h *Haproxy) generateCfg() error {
 
 // StartHaproxy ...
 func (h *Haproxy) StartHaproxy() error {
+	return startHaproxy()
+}
+
+func startHaproxy() error {
 	// restart haproxy container
 	session := sh.NewSession()
 	err := session.Command("haproxy", "-p", "/var/run/haproxy.pid", "-f", "/usr/local/etc/haproxy/haproxy.cfg").Run()
@@ -325,6 +329,10 @@ func (h *Haproxy) StartHaproxy() error {
 
 // ReloadHaproxy ...
 func (h *Haproxy) ReloadHaproxy() error {
+	return reloadHaproxy()
+}
+
+func reloadHaproxy() error {
 	session := sh.NewSession()
 	err := session.Command("/usr/bin/reload.sh").Run()
 	if err != nil {
@@ -348,6 +356,10 @@ func (h *Haproxy) Reload(r *http.Request, reloadStatus *ReloadStatus, result *Re
 
 // ValidateHaproxy ...
 func (h *Haproxy) ValidateHaproxy() error {
+	return validateHaproxy()
+}
+
+func validateHaproxy() error {
 	if _, err := os.Stat(haproxyPath + "/lock"); !os.IsNotExist(err) {
 		return fmt.Errorf("LOCKED")
 	}
@@ -525,6 +537,10 @@ func (h *Haproxy) BringOutOfLB(r *http.Request, ReloadStatus *ReloadStatus, resu
 
 //AddToReloadFile ... id -> refers to clusterName
 func (h *Haproxy) AddToReloadFile(ID string) error {
+	return addToReloadFile(ID)
+}
+
+func addToReloadFile(ID string) error {
 	if _, err := os.Stat(haproxyPath + "/lock"); !os.IsNotExist(err) {
 		return fmt.Errorf("LOCKED")
 	}
@@ -591,22 +607,39 @@ func HealthCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	version := flag.String("version", "v1", "v1 will run the old version while v2 will run the new version")
+	flag.Parse()
 	//if running without docker
 	if os.Getenv("CONF_PATH") != "" {
 		confPath = os.Getenv("CONF_PATH")
 	}
-
 	if os.Getenv("HAPROXY_PATH") != "" {
 		haproxyPath = os.Getenv("HAPROXY_PATH")
 	}
-
 	s := rpc.NewServer()
 	s.RegisterCodec(json.NewCodec(), "application/json")
-	haproxy := new(Haproxy)
-	// generate default haproxy.cfg
-	log.Println("Generating default haproxy.cfg")
-	haproxy.generateCfg()
-	err := haproxy.StartHaproxy()
+	r := mux.NewRouter()
+	r.HandleFunc("/health", HealthCheck).Methods("HEAD")
+	switch *version {
+	case "v1":
+		haproxy := new(Haproxy)
+		haproxy.generateCfg()
+		err := haproxy.StartHaproxy()
+		createLiveFile(err)
+		s.RegisterService(haproxy, "")
+		r.Handle("/haproxy", s)
+	case "v2":
+		haproxy := new(HaproxyV2)
+		haproxy.generateCfg()
+		err := haproxy.StartHaproxy()
+		createLiveFile(err)
+		s.RegisterService(haproxy, "")
+		r.Handle("/haproxy", s)
+	}
+	http.ListenAndServe(":34015", r)
+}
+
+func createLiveFile(err error) {
 	if err == nil {
 		session := sh.NewSession()
 		err = session.Command("touch", "/usr/local/etc/live").Run()
@@ -614,12 +647,4 @@ func main() {
 			log.Println("Failed to create the live File")
 		}
 	}
-	s.RegisterService(haproxy, "")
-	r := mux.NewRouter()
-	r.Handle("/haproxy", s)
-	//Route Added for Hap Health Check
-	log.Println("New routes")
-	r.HandleFunc("/health", HealthCheck).Methods("HEAD")
-	//r.HandleFunc("/Removefromqueue/{cluster}", RemoveFromQueue).Methods("POST")
-	http.ListenAndServe(":34015", r)
 }

--- a/localRun.sh
+++ b/localRun.sh
@@ -1,4 +1,8 @@
-docker rm -f hap
+#!/bin/bash
+set -e
+docker rm -f hap|true
 GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build .
 docker build -t hapreload .
 docker run -d -v $HOME/haproxy:/usr/local/etc/haproxy -p 8888:80 -p 443:443 -p 34015:34015 --name hap hapreload
+sleep 3
+docker exec -it hap tail -f /var/log/hapreload.log /var/log/haproxy.log

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 rsyslogd
-/usr/bin/hapreload > /var/log/hapreload.log 2>&1 &
+/usr/bin/hapreload -version=v2 > /var/log/hapreload.log 2>&1 &
 tail -f /dev/null

--- a/v2.go
+++ b/v2.go
@@ -47,11 +47,16 @@ type FrontendConfig struct {
 
 // Backend ...
 type Backend struct {
-	Name   string   `yaml:"name" json:"name"`
-	IPs    []string `yaml:"IPs" json:"IPs"`
-	Server string   `yaml:"server" json:"server"`
-	Port   int      `yaml:"port" json:"port"`
-	Tail   string   `yaml:"tail" json:"tail"`
+	Name    string   `yaml:"name" json:"name"`
+	Servers []Server `yaml:"servers" json:"servers"`
+	Port    int      `yaml:"port" json:"port"`
+	Tail    string   `yaml:"tail" json:"tail"`
+}
+
+// Server ...
+type Server struct {
+	Name string `yaml:"name" json:"name"`
+	IP   string `yaml:"IP" json:"IP"`
 }
 
 // HaproxyV2 ...
@@ -157,12 +162,18 @@ func (h *HaproxyV2) Update(r *http.Request, services *ServicesV2, result *Result
 		backends := ""
 		for _, singleBackend := range service.Backends {
 			backends += "\n\nbackend " + singleBackend.Name
-			for index, singleIP := range singleBackend.IPs {
+			for _, singleServer := range singleBackend.Servers {
 				backends += "\n\tserver " +
-					singleBackend.Server + "-" + strconv.Itoa(index) + " " +
-					singleIP + ":" + strconv.Itoa(singleBackend.Port) + " " +
+					singleServer.Name + " " +
+					singleServer.IP + ":" + strconv.Itoa(singleBackend.Port) + " " +
 					singleBackend.Tail
 			}
+			// for index, singleIP := range singleBackend.IPs {
+			// 	backends += "\n\tserver " +
+			// 		singleBackend.Server + "-" + strconv.Itoa(index) + " " +
+			// 		singleIP + ":" + strconv.Itoa(singleBackend.Port) + " " +
+			// 		singleBackend.Tail
+			// }
 		}
 		err := ioutil.WriteFile(confPath+"/"+service.ID+".backend", []byte(backends), 0777)
 		if err != nil {

--- a/v2.go
+++ b/v2.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	sh "github.com/codeskyblue/go-sh"
+)
+
+// ServicesV2 ...
+type ServicesV2 struct {
+	Services              []ServiceV2 `yaml:"services" json:"services"`
+	EnableFileBasedReload bool        `yaml:"enableFileBasedReload" json:"enableFileBasedReload"`
+	ID                    string      `yaml:"ID" json:"ID"`
+}
+
+// ServiceV2 ...
+type ServiceV2 struct {
+	ID        string     `yaml:"id" json:"id"`
+	Frontends []Frontend `yaml:"frontends" json:"frontends"`
+	Backends  []Backend  `yaml:"backends" json:"backends"`
+	Action    string     `yaml:"action" json:"action"`
+}
+
+// Frontend ...
+type Frontend struct {
+	FrontendName    string           `yaml:"frontendName" json:"frontendName"`
+	FrontendConfigs []FrontendConfig `yaml:"frontendConfigs" json:"frontendConfigs"`
+	DefaultBackend  string           `yaml:"defaultBackend" json:"defaultBackend"`
+	IsTop           bool             `yaml:"isTop" json:"isTop"`
+	IsBottom        bool             `yaml:"isBottom" json:"isBottom"`
+}
+
+// FrontendConfig ...
+type FrontendConfig struct {
+	ACLName    string   `yaml:"ACLName" json:"ACLName"`
+	ACLs       []string `yaml:"ACLs" json:"ACLs"`
+	UseBackend string   `yaml:"useBackend" json:"useBackend"`
+}
+
+// Backend ...
+type Backend struct {
+	Name   string   `yaml:"name" json:"name"`
+	IPs    []string `yaml:"IPs" json:"IPs"`
+	Server string   `yaml:"server" json:"server"`
+	Port   int      `yaml:"port" json:"port"`
+	Tail   string   `yaml:"tail" json:"tail"`
+}
+
+// HaproxyV2 ...
+type HaproxyV2 int
+
+func (h *HaproxyV2) generateCfg() error {
+	if _, err := os.Stat(haproxyPath + "/lock"); !os.IsNotExist(err) {
+		return fmt.Errorf("LOCKED")
+	}
+	if _, err := os.Stat(haproxyPath + "/haproxy.cfg"); !os.IsNotExist(err) {
+		currentTime := string(time.Now().Format("20060102150405"))
+		err := os.Rename(haproxyPath+"/haproxy.cfg", haproxyPath+"/haproxy.cfg.BAK."+currentTime)
+		if err != nil {
+			return fmt.Errorf("Error in backing up Haproxy.cfg: %s", err)
+		}
+	}
+	var haproxyCfg []byte
+	var partFunc = func(part string) {
+		// walk all files in the directory
+		filepath.Walk(confPath, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return fmt.Errorf("Error in walk through director of conf Folder: %s", err)
+			}
+			if !info.IsDir() && strings.HasSuffix(info.Name(), part) {
+				b, err := ioutil.ReadFile(path)
+				if err != nil {
+					return fmt.Errorf("Error in Generating the Haproxy.cfg: %s", err)
+				}
+				haproxyCfg = append(haproxyCfg, b...)
+			}
+			return nil
+		})
+	}
+	//append the configs in the following order
+	parts := []string{".globalcfg", ".defaultcfg"}
+	filepath.Walk(confPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("Error in walk through director of conf Folder: %s", err)
+		}
+		// Check if it is not a directory and has prefix .frontend
+		if !info.IsDir() && strings.Contains(info.Name(), ".frontend") && strings.HasSuffix(info.Name(), "cfg") {
+			frontendName := info.Name()[:len(info.Name())-3]
+			log.Println("Found frontend - ", frontendName)
+			parts = append(parts, info.Name(), frontendName+"top", frontendName, frontendName+"bottom", frontendName+"default_backend")
+		}
+		return nil
+	})
+	parts = append(parts, ".backend")
+	log.Println("Parts - ", parts)
+	for i := range parts {
+		partFunc(parts[i])
+	}
+	//write the file
+	err := ioutil.WriteFile(haproxyPath+"/haproxy.cfg", haproxyCfg, 0777)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// StartHaproxy ...
+func (h *HaproxyV2) StartHaproxy() error {
+	return startHaproxy()
+}
+
+// Update Add or Remove services from the Haproxy
+func (h *HaproxyV2) Update(r *http.Request, services *ServicesV2, result *Result) error {
+	time.Sleep(2)
+	if _, err := os.Stat(haproxyPath + "/lock"); !os.IsNotExist(err) {
+		*result = 0
+		return fmt.Errorf("LOCKED")
+	}
+	// var defaultBackend interface{}
+	for _, service := range services.Services {
+		removeServiceConfigurations(service, confPath)
+		log.Printf("Add service %+v", service) //, service.Port)
+		// Dont add the HAP Rule for the Service Which as to be deleted.
+		if service.Action == "Remove" {
+			continue
+		}
+		for _, singleFrontend := range service.Frontends {
+			frontendACLs := "\n"
+			frontendType := "." + singleFrontend.FrontendName
+			if singleFrontend.IsTop {
+				frontendType += "top"
+			}
+			if singleFrontend.IsBottom {
+				frontendType += "bottom"
+			}
+			for _, singleFrontendConfig := range singleFrontend.FrontendConfigs {
+				for _, singleACL := range singleFrontendConfig.ACLs {
+					frontendACLs += "\n\tacl " + singleFrontendConfig.ACLName + " " + singleACL
+				}
+				frontendACLs = frontendACLs + "\n\tuse_backend " + singleFrontendConfig.UseBackend + " if " + singleFrontendConfig.ACLName
+			}
+			log.Println(frontendACLs)
+			err := ioutil.WriteFile(confPath+"/"+service.ID+frontendType, []byte(frontendACLs), 0777)
+			if err != nil {
+				*result = 0
+				return fmt.Errorf("Error in creating the frontend files, Error:%s", err)
+			}
+		}
+		backends := ""
+		for _, singleBackend := range service.Backends {
+			backends += "\n\nbackend " + singleBackend.Name
+			for index, singleIP := range singleBackend.IPs {
+				backends += "\n\tserver " +
+					singleBackend.Server + "-" + strconv.Itoa(index) + " " +
+					singleIP + ":" + strconv.Itoa(singleBackend.Port) + " " +
+					singleBackend.Tail
+			}
+		}
+		err := ioutil.WriteFile(confPath+"/"+service.ID+".backend", []byte(backends), 0777)
+		if err != nil {
+			*result = 0
+			return fmt.Errorf("Error in creating the backend files, Error:%s", err)
+		}
+		for _, singleFrontend := range service.Frontends {
+			if singleFrontend.DefaultBackend != "" {
+				defaultBackendContent := "\n\tdefault_backend " + singleFrontend.DefaultBackend
+				err := ioutil.WriteFile(confPath+"/"+service.ID+"."+singleFrontend.FrontendName+"default_backend",
+					[]byte(defaultBackendContent), 0777)
+				if err != nil {
+					*result = 0
+					return fmt.Errorf("Error in creating the default backend file, Error:%s", err)
+				}
+			}
+		}
+	}
+	// join all the configs
+	if err := h.generateCfg(); err != nil {
+		for _, service := range services.Services {
+			removeServiceConfigurations(service, confPath)
+		}
+		if err := h.generateCfg(); err != nil {
+			*result = 0
+			return err
+		}
+		*result = 0
+		return err
+	}
+	if err := validateHaproxy(); err != nil {
+		for _, service := range services.Services {
+			removeServiceConfigurations(service, confPath)
+		}
+		if err := h.generateCfg(); err != nil {
+			*result = 0
+			return err
+		}
+		*result = 0
+		return err
+	}
+	if services.EnableFileBasedReload {
+		if err := addToReloadFile(services.ID); err != nil {
+			for _, service := range services.Services {
+				removeServiceConfigurations(service, confPath)
+			}
+			if err := h.generateCfg(); err != nil {
+				*result = 0
+				return err
+			}
+			*result = 0
+			return err
+		}
+	} else {
+		if err := reloadHaproxy(); err != nil {
+			*result = 0
+			return err
+		}
+	}
+	*result = 1
+	return nil
+}
+
+func removeServiceConfigurations(service ServiceV2, confPath string) {
+	log.Printf("Remove service %+v", service)
+	sh.Command("rm", "-f", confPath+"/"+service.ID+".backend").Run()
+	filepath.Walk(confPath, func(path string, fileInfo os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("Error in walk through director of conf Folder: %s", err)
+		}
+		if !fileInfo.IsDir() && strings.Contains(fileInfo.Name(), ".frontend") && strings.HasPrefix(fileInfo.Name(), service.ID) {
+			sh.Command("rm", "-f", confPath+"/"+fileInfo.Name()).Run()
+		}
+		return nil
+	})
+	sh.Command("rm", "-f", confPath+"/"+service.ID+".frontend*").Run()
+}


### PR DESCRIPTION
This change enables users to add mulitple frontend configs as params the haproxy reload. This will allow a more rich variety of ACLs to be configured for each service